### PR TITLE
Automatic Marginalization

### DIFF
--- a/amimodels/__init__.py
+++ b/amimodels/__init__.py
@@ -7,6 +7,9 @@ This package contains models for advanced metering infrastructure (AMI) data.
 """
 from __future__ import division, absolute_import, print_function
 
+# Load step methods into pymc registry:
+from .step_methods import *
+
 #from .normal_hmm import *
 
 VERSION = (0, 0, 1)

--- a/amimodels/deterministics.py
+++ b/amimodels/deterministics.py
@@ -289,7 +289,7 @@ def get_indexed_items(node):
         col = node.parents['choices']
         res = (idx, col)
     elif isinstance(node, HMMLinearCombination):
-        idx = node.states
+        idx = node.which_k
         col = node.k_prods
         res = (idx, col)
     elif isinstance(node, MergeIndexed):

--- a/amimodels/deterministics.py
+++ b/amimodels/deterministics.py
@@ -17,15 +17,18 @@ NumpyChoose = deterministic_from_funcs("choose", np.choose)
 NumpyPut = deterministic_from_funcs("put", np.put)
 NumpyStack = deterministic_from_funcs("stack", np.stack)
 NumpyHstack = deterministic_from_funcs("hstack", np.hstack)
+NumpyBroadcastArrays = deterministic_from_funcs("broadcast_arrays",
+                                                np.broadcast_arrays)
 NumpyMultidot = deterministic_from_funcs("multi_dot", np.linalg.multi_dot)
 
 
 class KIndex(pymc.Deterministic):
     r""" A deterministic that dynamically tracks which time/first axis
-    indices correspond to a given state.
+    indices correspond to a given integer value.
 
-    It keeps a static record of the indices it creates; that way it
-    doesn't make duplicates for a given dynamic state sequence.
+    It keeps a static record of the indices it creates inside of
+    any pymc.Node that is being indexed.  That means we don't create
+    duplicates for the same k-index.
 
     XXX: Can't trace these Deterministics, since they change shape.
     """

--- a/amimodels/deterministics.py
+++ b/amimodels/deterministics.py
@@ -14,6 +14,8 @@ from pymc.NumpyDeterministics import deterministic_from_funcs
 
 NumpyTake = deterministic_from_funcs("take", np.take)
 NumpyChoose = deterministic_from_funcs("choose", np.choose)
+NumpyPut = deterministic_from_funcs("put", np.put)
+NumpyStack = deterministic_from_funcs("stack", np.stack)
 
 
 class KIndex(pymc.Deterministic):
@@ -32,9 +34,9 @@ class KIndex(pymc.Deterministic):
 
             if k_index is not None:
                 return k_index
-        else:
-            return super(KIndex, cls).__new__(cls, k, states,
-                                              *args, **kwds)
+
+        return super(KIndex, cls).__new__(cls, k, states,
+                                          *args, **kwds)
 
     def __init__(self, k, states, *args, **kwds):
         r"""
@@ -137,7 +139,8 @@ class HMMLinearCombination(pymc.Deterministic):
         for k in xrange(self.N_states):
 
             w_k = KIndex(k, states)
-            X_k_mat = NumpyTake(X_matrices[k], w_k, axis=0)
+            X_k_mat = NumpyTake(np.asarray(X_matrices[k]),
+                                w_k, axis=0)
 
             this_beta = betas[k]
             k_p = pymc.LinearCombination("mu_{}".format(k),
@@ -166,3 +169,4 @@ class HMMLinearCombination(pymc.Deterministic):
                                                    *args, **kwds)
 
 
+indexers = (NumpyTake, NumpyChoose, KIndex)

--- a/amimodels/graph.py
+++ b/amimodels/graph.py
@@ -1,0 +1,1054 @@
+r"""
+This module provides graph parsing methods for PyMC2 models.
+
+.. moduleauthor:: Brandon T. Willard
+"""
+from functools import partial
+from operator import (mul, pow, is_, itemgetter, isNumberType)
+from itertools import (chain, cycle, izip)
+
+import numpy as np
+import pymc
+
+from .stochastics import dvalue_class
+
+from .deterministics import (NumpySum, NumpyBroadcastTo, NumpyAlen,
+                             MergeIndexed, get_indexed_items)
+
+
+def izip_repeat(*args):
+    arg_groups = [(len(v), list(v)) for v in args]
+    largest_len = max(v[0] for v in arg_groups)
+    adj_args = chain(iter(a) if l == largest_len else cycle(a)
+                     for l, a in arg_groups)
+    res = izip(*adj_args)
+    return res
+
+
+def node_eq(x, y):
+    """ Compare nodes by parent structure and values, i.e.
+    in a symbolic fashion.
+
+        mu = pymc.Normal('mu_y', 0, 1, size=10)
+        node = pymc.Normal('y', mu, 1, size=10)
+        assert node_eq(node, node)
+        assert not node_eq(node[0], node)
+        assert node_eq(node[0], node[0])
+
+        node_2 = pymc.Normal('y_2', mu, 1, size=10)
+        assert node_eq(node_2, node)
+        assert node_eq(node, node_2)
+
+        mu.parents['mu'] = 4
+        assert node_eq(node, node_2)
+        assert node_eq(node_2, node)
+
+        node_3 = pymc.Normal('y_3', mu, 2, size=10)
+        assert not node_eq(node_3, node)
+
+        node_4 = pymc.Normal('y_4', mu, np.ones(10), size=10)
+        assert node_eq(node_4, node)
+
+        assert node_eq(node_4[0:5], node_4[0:5])
+
+        assert not node_eq(node_4[0:5], node_4[0:6])
+    """
+    if x is y:
+        return True
+    elif y is None:
+        return False
+
+    if isinstance(x, pymc.Node) and isinstance(y, pymc.Node):
+
+        if type(x) != type(y):
+            return False
+
+        return all(node_eq(v_, y.parents.get(k_))
+                   for k_, v_ in x.parents.iteritems())
+
+    elif isNumberType(x) and isNumberType(y):
+        return np.array_equiv(x, y)
+    else:
+        return x == y
+
+
+def get_non_node(x, y, node):
+    """ From two of three nodes, choose the one that doesn't match
+    the excluded "base" node and throw an exception if the two
+    choices are unique (and neither is the base node).
+
+    This, when used with `reduce`, produces a filter that can be used
+    to...
+
+    Examples speak louder than words:
+
+        from functools import partial
+        mu = pymc.Normal('mu', 0, 1, size=10)
+        node = pymc.Normal('y', mu, 1, size=10)
+        cmp_nodes = partial(get_non_node, node=node)
+
+        # These are ok
+        reduce(cmp_nodes, [node, node[range(1)], node, node])
+        # <pymc.PyMCObjects.Deterministic 'y[[0]]' at 0x7fd608a5f890>
+
+        reduce(cmp_nodes, [node[range(1)]])
+        # <pymc.PyMCObjects.Deterministic 'y[[0]]' at 0x7fd608a5f890>
+
+        reduce(cmp_nodes, [node, node])
+        # <pymc.distributions.Normal 'y' at 0x7fd5e4a27210>
+
+        reduce(cmp_nodes, [node])
+        # <pymc.distributions.Normal 'y' at 0x7fd5e4a27210>
+
+        reduce(cmp_nodes, [node[range(1)], node[range(1)]])
+        # <pymc.PyMCObjects.Deterministic 'y[[0]]' at 0x7fd608a5f890>
+
+        # XXX: Not OK!
+        reduce(cmp_nodes, [node[range(1)], node[range(3)]])
+
+    """
+    if isinstance(x, pymc.Node) and\
+            isinstance(y, pymc.Node):
+        if node_eq(x, y):
+            return x
+
+        if not node_eq(x, node):
+            if not node_eq(y, node):
+                raise ValueError('Heterogeneous nodes')
+            return x
+        else:
+            return y
+    else:
+        if np.alen(x) < np.alen(y):
+            return x
+        else:
+            return y
+
+
+def static_vars(**kwargs):
+    """ Decorator for "function-static" variables.
+
+    Might be worth trying with our `put`/array setting
+    deterministics; perhaps we could save on allocations.
+    XXX: Would very likely ruin any asynchronous use of such
+    deterministics, though.
+
+    .. _source:
+        http://stackoverflow.com/a/279586
+
+    """
+    def decorate(func):
+        for k in kwargs:
+            setattr(func, k, kwargs[k])
+        return func
+    return decorate
+
+
+def get_mul_type(node, allow_pow=False):
+    """
+        node = pymc.Normal('', 0, 1, size=4)
+        n = node * node
+        get_mul_type(n)
+        # <ufunc 'multiply'>
+    """
+    if isinstance(node, pymc.Deterministic):
+        if isinstance(node, pymc.LinearCombination):
+            return np.dot
+        try:
+            func = node._value.fun.__closure__[0].cell_contents
+            if func is mul:
+                return np.multiply
+            elif allow_pow and func is pow:
+                return np.power
+        except:
+            pass
+
+    return None
+
+
+def extract_term_mul(node, func=lambda *args: False,
+                     m_type_last=None):
+    """ Creates a list of nodes used in a--potentially nested--
+    deterministic product.
+    Using ``func`` is like dividing by whatever yields func == True.
+
+    For example:
+
+        extract_term_mul(1)
+        # (1, None)
+
+        extract_term_mul(np.ones(2))
+        # (array([ 1.,  1.]), None)
+
+        node_1 = pymc.Normal('y', 0, 1, size=10)
+        extract_term_mul(node_1)
+        # [(<pymc.distributions.Normal 'y' at 0x7f87ad78d150>, <ufunc 'multiply'>),
+        # (2, None)]
+
+        extract_term_mul(node_1 * 2)
+        # [(<pymc.distributions.Normal 'y' at 0x7f87ad78d150>, <ufunc 'multiply'>),
+        # (2, None)]
+
+        assert set(extract_term_mul(node_1 * 2 * 5)) ==\
+            set(extract_term_mul(2 * node_1 * 5))
+
+        extract_term_mul(node_1 * 2 * 5)
+        # [(<pymc.distributions.Normal 'y' at 0x7f87ad78d150>, <ufunc 'multiply'>),
+        #  (2, <ufunc 'multiply'>),
+        #  (5, None)]
+
+        extract_term_mul(node_1 * 2 * 5, func=lambda x: x is node_1)
+        #  [(None, <ufunc 'multiply'>), (2, <ufunc 'multiply'>), (5, None)]
+
+        extract_term_mul(3 * node_1 * node_1[3] * 2,
+                         func=lambda x: node_eq(x, node_1[3]))
+        # [(3, <ufunc 'multiply'>),
+        #  (<pymc.distributions.Normal 'y' at 0x7f87ad78d150>, <ufunc 'multiply'>),
+        #  (None, <ufunc 'multiply'>),
+        #  (2, None)]
+
+        node_lc = pymc.LinearCombination('', (np.ones((2, 2)),), (node_1[0:2],))
+        extract_term_mul(3 * node_lc * 2)
+        # [(3, <ufunc 'multiply'>), (array([[ 1.,  1.],
+        #          [ 1.,  1.]]),
+        #   <function numpy.core.multiarray.dot>), (<pymc.PyMCObjects.Deterministic 'y[slice(0, 2, None)]' at 0x7f05e6eeb890>, <ufunc 'multiply'>), (2,
+        #   None)]
+
+        extract_term_mul(3 * node_lc * 2, func=lambda x: node_eq(x, node_1[0:2]))
+
+        # [(3, <ufunc 'multiply'>), (array([[ 1.,  1.],
+        #          [ 1.,  1.]]), <function numpy.core.multiarray.dot>), (None,
+        #   <ufunc 'multiply'>), (2, None)]
+
+        # Doesn't handle powers...
+        assert set(extract_term_mul(node_1 * node_1)) !=\
+            set(extract_term_mul(node_1**2))
+
+        # It should also maintain the order of terms:
+        from operator import mul
+        extract_term_mul(reduce(mul, [node_1] + range(5)))
+        # [(<pymc.distributions.Normal 'y' at 0x7f05e704c390>, <ufunc 'multiply'>),
+        #  (0, <ufunc 'multiply'>),
+        #  (1, <ufunc 'multiply'>),
+        #  (2, <ufunc 'multiply'>),
+        #  (3, <ufunc 'multiply'>),
+        #  (4, None)]
+
+        # TODO: Get NumpyBroadcastArrays and NumpyMultidot working.
+    """
+    m_type = get_mul_type(node)
+
+    # pymc.LinearCombination fix:
+    if isinstance(node, (list, tuple)):
+        node, = node
+
+    if m_type is not None:
+        mul_args = sorted(node.parents.iteritems(),
+                          key=itemgetter(0))
+        res = (extract_term_mul(mul_args[0][1],
+                                func, m_type_last=m_type),
+               extract_term_mul(mul_args[1][1],
+                                func, m_type_last=m_type_last))
+        return list(chain.from_iterable(res))
+    elif not func(node):
+        return ((node, m_type_last),)
+    else:
+        return ((None, m_type_last),)
+
+
+def node_shape(x):
+    if isinstance(x, pymc.Deterministic):
+        return np.shape(pymc.utils.value(x))
+    else:
+        return np.shape(x)
+
+
+def commute(prod_elems, func):
+    """ Commute a term in a list as far to the right as possible.
+
+    Parameters
+    ==========
+    prod_elems: iterable of `(node, prod_type)`
+        An iterable containing tuples of node and product-type elements.
+        Product-type elements are one of (np.dot, np.multiply).
+        Really whatever `extract_term_mul` returns.
+    func: function
+        A single argument boolean function that identifies the term to be
+        commuted.
+
+    Returns
+    =======
+    iterable of `(node, prod_type)`
+        An iterable with the same elements as ``prod_elems`` but with
+        the ``func`` identified term commuted, if possible.
+
+
+    Examples
+    ========
+
+        node = pymc.Normal('', 0, 1, size=4)
+
+        func = lambda x_: isinstance(x_, type(node))
+
+        prod_elems = ((pymc.Lambda('', lambda x_=np.ones((5,4)): x_), np.dot),
+                    (node, np.multiply),
+                    (np.ones(5), None))
+
+        commuted_elems = commute(prod_elems, func)
+
+        def check_commute(start_elems, end_elems):
+            start_res = reduce(lambda a, b: (a[1](pymc.utils.value(a[0]),
+                                                pymc.utils.value(b[0])), b[1]),
+                            start_elems)
+            end_res = reduce(lambda a, b: (a[1](pymc.utils.value(a[0]),
+                                                pymc.utils.value(b[0])), b[1]),
+                            end_elems)
+
+            return start_res[0], end_res[0]
+
+        assert np.array_equal(*check_commute(prod_elems, commuted_elems))
+
+        prod_elems = ((pymc.Lambda('', lambda x_=np.ones((4,4)): x_), np.dot),
+                    (node, np.multiply),
+                    (np.ones(4), None))
+
+        commuted_elems = commute(prod_elems, func)
+        assert np.array_equal(*check_commute(prod_elems, commuted_elems))
+
+        prod_elems = ((pymc.Lambda('', lambda x_=np.ones((4,4)): x_), np.dot),
+                    (node, np.multiply),
+                    (np.array(1), None))
+
+        commuted_elems = commute(prod_elems, func)
+        assert np.array_equal(*check_commute(prod_elems, commuted_elems))
+
+        prod_elems = ((np.array(1), None),)
+
+        commuted_elems = commute(prod_elems, func)
+        assert np.array_equal(*check_commute(prod_elems, commuted_elems))
+
+        prod_elems = ((np.array(1), None),)
+
+        commuted_elems = commute(prod_elems, func)
+        assert np.array_equal(*check_commute(prod_elems, commuted_elems))
+
+    """
+    if len(prod_elems) == 1:
+        return prod_elems
+    # Track whether we've seen a dot product in the chain.
+    # We need this to signal that we've lost shape information.
+    # TODO: If the chain contains only arrays and stochastics, we
+    # might actually be able to track shape information.
+    seen_dot = False
+
+    res = [prod_elems[0]]
+    for b in prod_elems[1:]:
+        a_ = res[-1]
+        a_val = a_[0]
+        a_mul_type = a_[1]
+
+        if a_mul_type is np.dot:
+            seen_dot = True
+
+        b_val = b[0]
+        b_mul_type = b[1]
+
+        # We can't get reliable enough shape information for deterministics,
+        # so we assume they can't commute.
+        if func(a_val):
+            a_shape = np.shape(a_val) if (isinstance(a_val, pymc.Stochastic) or
+                                          not isinstance(a_val, pymc.Node)) else None
+
+            b_shape = np.shape(b_val) if (isinstance(b_val, pymc.Stochastic) or
+                                          not isinstance(b_val, pymc.Node)) else None
+
+            # Scalars can commute with anything.
+            if a_shape == () or b_shape == ():
+                if len(res) > 1:
+                    # Unless it's all scalar products, the product before these
+                    # two need to be scalar multiplied, and the result of that
+                    # dotted or whatever else.
+                    ur_res = res[-2]
+                    res[-2] = (ur_res[0], a_mul_type)
+                    res[-1] = (b_val, ur_res[1])
+                else:
+                    res[-1] = (b_val, a_mul_type)
+                res += [(a_val, b_mul_type)]
+
+            # Otherwise, we can commute when Hadamard multiplying equal shapes.
+            elif not seen_dot and (a_shape == b_shape and
+                                   a_mul_type is np.multiply):
+                res[-1] = (b_val, a_mul_type)
+                res += [(a_val, b_mul_type)]
+        else:
+            res += [b]
+
+    return res
+
+
+def get_linear_parts(node, func, mu_name=''):
+    """ Creates a pymc.LinearCombination from a
+    nested product and attempts to make one of the terms
+    the node that makes ``func`` return True.
+
+    Parameters
+    ==========
+    node: pymc.Node
+        Potential linear combination node.
+    func: function
+        Filter for determining right product term.
+    Returns
+    =======
+    pymc.LinearCombination
+    """
+    prod_elems = extract_term_mul(node)
+
+    if len(prod_elems) <= 1:
+        left_term = 1
+        right_term = node
+    else:
+        commuted_elems = commute(prod_elems, func)
+        left_term = reduce(lambda a, b: (a[1](a[0], b[0]), b[1]),
+                           commuted_elems[:-1])[0]
+        right_term = commuted_elems[-1][0]
+
+    mu_k = pymc.LinearCombination(mu_name, (left_term,),
+                                  (right_term,))
+
+    return mu_k
+
+
+# TODO: Use something like LogPy.
+conjugate_relations = {pymc.Normal: {'mu': pymc.Normal, 'tau': pymc.Gamma}}
+
+
+def parse_partition(node, parent, parent_name):
+    """ Creates the partitioned LinearCombinations of a node's parents.
+
+    Parameters
+    ==========
+    node: pymc.Node
+        The node.
+    parent: pymc.Node
+        Single parent of ``node``
+    parent_name: str
+        Name of parent node.
+
+    Returns
+    =======
+    tuple
+    """
+
+    #
+    # Check for a mask corresponding to missing values.
+    #
+    node_mask = getattr(node, 'mask', None)
+    if node_mask is not None and np.any(node_mask):
+        node_mask = np.squeeze(node_mask)
+    else:
+        node_mask = None
+
+    #
+    # When our stochastic really applies to a subset of
+    # observations, make sure we use only those.
+    #
+    parts = ()
+    if isinstance(parent, pymc.LinearCombination):
+
+        X, = parent.x
+        beta, = parent.y
+        mu_name = '{}_{}'.format(parent_name, node.__name__)
+        mu = pymc.LinearCombination(mu_name,
+                                    [X], [beta])
+        parts += ({parent_name: mu, 'value': node},)
+
+    elif isinstance(parent, pymc.Deterministic):
+        # Parse indexed collections of linear combinations
+        # (or things that can be turned into linear combinations).
+
+        k_idx_s, mu_s = get_indexed_items(parent)
+
+        for k, (mu_k_, k_idx) in enumerate(zip(mu_s, k_idx_s)):
+
+            mu_name = '{}_{}_{}'.format(parent_name, node.__name__, k)
+            conj_dist = conjugate_relations.get(type(node), {})
+            conj_dist = None if conj_dist is None else conj_dist.get(parent_name)
+            mu_k = get_linear_parts(mu_k_,
+                                    lambda x_: isinstance(x_, conj_dist),
+                                    mu_name)
+
+            if k_idx is not None:
+                node_k = node[k_idx]
+            else:
+                node_k = node
+
+            if node_mask is not None:
+                if k_idx is not None:
+                    y_k_mask = pymc.Lambda('{}_idx'.format(k),
+                                           lambda k_m_=k_idx, y_m_=node_mask:
+                                           y_m_[k_m_], trace=False)
+                else:
+                    y_k_mask = node_mask
+
+                node_k._mask = y_k_mask
+
+            parts += ({parent_name: mu_k, 'value': node_k},)
+
+    else:
+        mu_name = '{}_{}'.format(parent_name, node.__name__)
+        mu = pymc.LinearCombination(mu_name,
+                                    [1], [parent])
+        parts += ({parent_name: mu, 'value': node},)
+
+    return parts
+
+
+def parse_node_partitions(node):
+    """ Creates the collections of partitioned nodes, if any, needed to
+    construct a marginal and/or posterior.
+
+    This scheme accounts for discrete, stochastic partitions of
+    observation indices, as seen in Hidden Markov Models, etc.
+
+    This function only applies to univariate distributions
+    and assumes that partitions on the first dimension of a node
+    must also apply to the first dimension of its parents, and
+    vice versa.
+
+    .. todo:
+        The last condition is probably too strong.
+
+    It starts by trying to identify partitions in the parents of a
+    source ``node``.  Those partitions are returned as a list of dicts
+    like the following:
+
+        ({'<parent_name>': parent_node_part_1, 'value': value_node_part_1},
+         ...,
+         {'<parent_name>': parent_node_part_n, 'value': value_node_part_n})
+
+    We then take the list of these dicts, for each parent, and zip them
+    together, naively repeating the shorter lists, so that we ultimately have
+    a list of dicts with parent name and node pairs.  Since there are multiple
+    'value' items, we have to choose one of them so that we have the
+    kwargs necessary to produce distributions for each partition of ``node``.
+
+    .. todo:
+        We should actually "broadcast" the shorter lists; checking
+        that the dimensions match.
+
+    Simply put, we want the "finest" partitioning found among all the parent nodes.
+    However, there can be multiple, non-identical "finest" partitions.
+
+    Take a pymc.Normal with size > 1 and a 'mu' parameter node that's partitioned
+    into N-many parts via indexing by some sequence/array along the first axis.
+    If the 'tau' parameter node is similarly partitioned into N-many parts,
+    but by a different sequence/array, we are left with multiple partitions
+    for the base ``node``.
+
+    Parameters
+    ==========
+    node: pymc.Node
+        The node.
+
+    Returns
+    =======
+    tuple
+        Collection of partitions of ``node``.
+    """
+
+    parents_parts = [np.asarray(parse_partition(node, v_, k_))
+                     for k_, v_ in node.parents.items()]
+
+    def unique_pairwise(iterable):
+        it = iter(iterable)
+        try:
+            total = next(it)
+        except StopIteration:
+            return
+        yield total
+        for e in it:
+            total = total if node_eq(total, e) else e
+            yield total
+
+    parent_indices = [list(unique_pairwise(map(itemgetter('value'), p_p)))
+                      for p_p in parents_parts]
+
+    # FIXME: Only using the values from the first list `max` picks!
+    value_parts = max(parent_indices, key=len)
+
+    zipped_parts = np.broadcast_arrays(*parents_parts)
+    zipped_parts = np.asarray(zipped_parts).T
+
+    node.partitions = ()
+    for n, (n_parents, n_value) in enumerate(zip(zipped_parts,
+                                                 value_parts)):
+
+        parent_args = chain.from_iterable(
+            [(k, v) for k, v in z.items() if k is not 'value']
+            for z in n_parents)
+
+        parent_args = dict(parent_args)
+        parent_args.update({'value': n_value})
+
+        if node.observed:
+            parent_args.update({'observed': True})
+
+        part_node = dvalue_class(pymc.Normal,
+                                 '{}-{}'.format(node.__name__, n),
+                                 **parent_args)
+
+        part_node._mask = getattr(n_value, "_mask", None)
+        node.partitions += (part_node,)
+
+    return node.partitions
+
+
+def update_marginal_part(parent_name,
+                         marginal_parent,
+                         node_part,
+                         node_idx, node):
+
+    def mu_put(m_full_=marginal_parent,
+               m_part_=node_part,
+               n_i_=node_idx,
+               s_=np.shape(node)):
+        res = np.empty(s_)
+        if m_full_ is not None:
+            np.copyto(res, m_full_)
+        np.put(res, n_i_, m_part_)
+        return res
+
+    res = pymc.Lambda('{}_{}_marg'.format(parent_name,
+                                          node.__name__),
+                       mu_put, trace=False)
+    return res
+
+
+def normal_node_update(node, updates):
+    """ Constructs the marginal for a given node and
+    the posteriors for some of its parents (when possible).
+
+    Parameters
+    =========
+    node: pymc.Node
+        The node for which we want to produce marginals.
+    updates: collection
+        This parameter is the output of `parse_normal` for ``node``.
+
+    Returns
+    =======
+    None
+        This function adds fields `*.marginals` and `*.posteriors` to ``node``
+        and its applicable parents, repectively.
+    """
+
+
+    node_marginals = ()
+
+    for k, node_k in enumerate(updates):
+        mu_k = node_k.parents['mu']
+        tau_k = node_k.parents['tau']
+
+        # We can get an index from the value (well, its
+        # "generator"); otherwise, try to get it directly
+        # off the node.
+        node_idx, _ = get_indexed_items(getattr(node_k,
+                                                '_dvalue',
+                                                node_k))
+
+        # The right-most term should be a gamma, if any.
+        if isinstance(tau_k, pymc.LinearCombination):
+            tau_k_gam, = tau_k.y
+        else:
+            tau_k_gam = tau_k
+
+        # Log the terms we are marginalizing.
+        marginal_wrt = ()
+
+        if isinstance(mu_k.y[0], pymc.Normal):
+            # Normal-Normal Update
+            beta_k, = mu_k.y
+            X_k, = mu_k.x
+
+            # Log the term we are marginalizing.
+            marginal_wrt += (beta_k,)
+
+            # Get a delayed/promised marginal distribution object.
+            # If we create it now, then it will become a dependency/child
+            # of all its parents, and that can be super annoying when
+            # only the marginal moments are needed.
+            node_marginal = norm_norm_marginal(beta_k, mu_k, tau_k, node_k)
+
+            #
+            # Compute the mu/mean/beta posterior.
+            #
+            # TODO: This should probably be its own thing (e.g. in a pass
+            # through the entire graph we would do this when arriving at the
+            # mu/mean/beta node), but we're doing it here because it's
+            # convenient.
+            beta_post = norm_norm_post(beta_k, node_k, mu_k, tau_k)
+
+            # (Re)set these so that any updates to follow use the marginal
+            # values.
+            # XXX: This isn't really robust, but it works for now.
+            mu_k = node_marginal.func_defaults[1].get('mu')
+            tau_k = node_marginal.func_defaults[1].get('tau')
+
+
+        # Divide out tau_k_gam from the (potentially marginalized)
+        # node partition (i.e. node_k).
+        tau_k_parts = get_linear_parts(tau_k, partial(is_, tau_k_gam))
+
+        if isinstance(tau_k_gam, pymc.Gamma) and\
+                tau_k_parts.y[0] is tau_k_gam:
+            # Normal-Gamma Update
+
+            # Log the term we are marginalizing.
+            marginal_wrt += (tau_k_gam,)
+
+            node_marginal = norm_gamma_marginal(tau_k_gam,
+                                                mu_k, tau_k_parts.x[0],
+                                                node_k,
+                                                name_prefix=node_k.__name__)
+
+            node_posterior = norm_gamma_post(tau_k_gam,
+                                             mu_k, tau_k_parts.x[0],
+                                             node_k)
+
+        node_marginals += ((node_marginal, node_idx, marginal_wrt),)
+
+    # Partition updates are over, now construct the total marginal (if
+    # possible).
+    marginal_dist_cls = None
+    from collections import defaultdict
+    marginal_parent_parts = defaultdict(list)
+    marginal_partitions = ()
+    for node_marginal, node_idx, marginal_wrt in node_marginals:
+
+        # We actually create/register this distribution/node now.
+        marginal_partitions += (node_marginal(),)
+
+        if marginal_dist_cls is not None and\
+                marginal_dist_cls is not node_marginal.func_defaults[0]:
+            # FIXME: We do not handle multiple marginal forms.
+            return
+        else:
+            marginal_dist_cls = node_marginal.func_defaults[0]
+
+        for parent_name in marginal_dist_cls.parent_names:
+            parent = node_marginal.func_defaults[1].get(parent_name)
+            marginal_parent_parts[parent_name].append((parent, node_idx))
+
+    marginal_parents = {}
+    for parent_name, parent_parts in marginal_parent_parts.items():
+
+        obj_idx_lists = zip(*parent_parts)
+
+        # TODO: Look for shared product terms in the parts.
+        #[get_linear_parts(o_, lambda x_: isinstance(x_, pymc.Stochastic))
+        # for o_ in obj_idx_lists[0]]
+
+        merged_parents = MergeIndexed(*obj_idx_lists)
+        marginal_parents[parent_name] = merged_parents
+
+    marginal_parents.update({'observed': node.observed,
+                             'value': node.value})
+    full_marginal = marginal_dist_cls("{}-marginal".format(node.__name__),
+                                      **marginal_parents)
+    full_marginal._mask = node.mask
+    full_marginal.partitions = marginal_partitions
+    full_marginal.ismarginal = True
+    full_marginal.marginalized = node
+    full_marginal.marginal_wrt = pymc.SetContainer(marginal_wrt)
+
+    marginals = getattr(node, 'marginals', tuple())
+    marginals = marginals + (full_marginal,)
+
+    node.marginals = pymc.TupleContainer(marginals)
+
+
+def norm_norm_marginal(beta_rv, mu_obs, tau_obs, node,
+                       name_prefix='', **kwargs):
+    r""" Create a marginal stochastic for a normal variable with a mean
+    parameter consisting of a linearly transformed normally distributed
+    variable.
+
+
+    Parameters
+    ==========
+    beta_rv: pymc.Variable, or np.ndarray
+        The prior `pymc.Normal` distribution.
+    mu_obs: beta_rv or pymc.LinearCombination
+        The observation/likelihood Normal mean
+    tau_obs: pymc.Node
+        The observation/likelihood Normal precision.
+    node: pymc.Node
+        The node being marginalized.
+    name_prefix: str (optional)
+        Prefix for name of resulting `pymc.Node`.
+
+    Returns
+    =======
+    A function that creates the marginal distribution.
+    """
+    n_name_pre = '{}-{}-marg'.format(name_prefix,
+                                     beta_rv.__name__)
+
+    mu_obs_parts = get_linear_parts(mu_obs, partial(is_, beta_rv))
+    X, = mu_obs_parts.x
+
+    mu_beta = NumpyBroadcastTo(beta_rv.parents['mu'], beta_rv.shape)
+
+    mu_marginal = pymc.LinearCombination('', (X,), (mu_beta,))
+
+    tau_beta = beta_rv.parents['tau']
+
+    tau_beta_parts = get_linear_parts(tau_beta,
+                                      lambda x_: isinstance(x_, pymc.Gamma))
+    tau_beta_gam, = tau_beta_parts.y
+    tau_beta_const, = tau_beta_parts.x
+
+    tau_obs_parts = get_linear_parts(tau_obs,
+                                     partial(is_, tau_beta_gam))
+
+    tau_obs_gam, = tau_obs_parts.y
+    tau_obs_const, = tau_obs_parts.x
+    # Generally, this is what we're computing
+    #
+    # tau_marginal = 1/(1/tau_obs + ((X / tau_beta) * X).sum(axis=1))
+    #              = tau_obs/(1 + ((X * (tau_obs / tau_beta)) * X).sum(axis=1))
+    #
+    # so if tau_beta = C * tau_obs,
+    #
+    # tau_marginal = tau_obs/(1 + ((X * (1 / C)) * X).sum(axis=1))
+    #
+    tau_ratio_base = 1. / tau_beta_const
+
+    if tau_obs_gam is not tau_beta_gam:
+        tau_ratio_base = tau_ratio_base * tau_obs_gam / tau_beta_gam
+
+    #tau_beta_gam = NumpyBroadcastTo(tau_beta_gam, beta_rv.shape)
+
+    X_P = X * tau_ratio_base
+    X_P_X = NumpySum(X_P * X, axis=1)
+    tau_marginal_part = (1./tau_obs_const + X_P_X)**(-1)
+    tau_marginal = pymc.LinearCombination('', (tau_marginal_part,),
+                                          (tau_obs_gam,))
+
+    marginal_name = '{}-marginal'.format(n_name_pre)
+    kwargs.update({'mu': mu_marginal,
+                   'tau': tau_marginal,
+                   'trace': False})
+
+    if node.observed:
+        kwargs.update({'value': node._dvalue,
+                       'observed': True})
+
+    def create_inst(dist=pymc.Normal, kwargs=kwargs):
+        if kwargs.get('observed', False):
+            node_marginal = dvalue_class(dist, marginal_name, **kwargs)
+        else:
+            node_marginal = dist(marginal_name, **kwargs)
+
+        node_marginal._mask = getattr(node, 'mask', None)
+        node_marginal.ismarginal = True
+        node_marginal.marginalized = node
+        node_marginal.marginal_wrt = pymc.SetContainer((beta_rv,))
+
+        return node_marginal
+
+    return create_inst
+
+
+def norm_gamma_marginal(tau_k_gam, mu_k, tau_k, node,
+                        name_prefix='', **kwargs):
+    """ Computes the normal with gamma precision prior conjugate
+    marginalization.
+
+    Parameters
+    ==========
+    tau_k_gam: pymc.Gamma
+        The gamma precision prior.
+    mu_k: pymc.Node
+        Normal observation/likelihood mean.
+    tau_k: pymc.Node
+        Normal observation/likelihood variance.
+    node: pymc.Node
+        The node being marginalized.
+    name_prefix: str (optional)
+        Prefix for name of resulting `pymc.Node`.
+
+    Returns
+    =======
+    pymc.Node
+        The marginal NoncentralT.
+    """
+
+    t_nu = 2. * tau_k_gam.parents['alpha']
+    t_lambda = tau_k * t_nu / tau_k_gam.parents['beta']
+
+    node_marg_parents = {'mu': mu_k,
+                         'lam': t_lambda,
+                         'nu': t_nu}
+
+    marginal_name = "{}-tau-marg".format(name_prefix)
+    kwargs.update(node_marg_parents)
+
+    if node.observed:
+        kwargs.update({'value': node._dvalue,
+                       'observed': True})
+
+    def create_inst(dist=pymc.NoncentralT, kwargs=kwargs):
+        if kwargs.get('observed', False):
+            node_marginal = dvalue_class(dist, marginal_name, **kwargs)
+        else:
+            node_marginal = dist(marginal_name, **kwargs)
+
+        node_marginal._mask = getattr(node, 'mask', None)
+        node_marginal.ismarginal = True
+        node_marginal.marginalized = node
+        node_marginal.marginal_wrt = pymc.SetContainer((tau_k_gam,))
+
+        return node_marginal
+
+    return create_inst
+
+
+def norm_gamma_post(prior, node, mu_lik=None, tau_lik=None,
+                    **kwargs):
+    """ Computes the normal with gamma precision prior conjugate
+    posterior.
+
+    Parameters
+    ==========
+    prior: pymc.Gamma
+        The gamma precision prior.
+    node: pymc.Node
+        Normal observation/likelihood.
+    mu_lik: pymc.Node (optional)
+        Normal likelihood mean.
+    tau_lik: pymc.Node (optional)
+        Normal likelihood precision.
+
+    Returns
+    =======
+    pymc.Node
+        The posterior pymc.Gamma.
+    """
+    if mu_lik is None:
+        mu_lik = node.parents['mu']
+
+    if tau_lik is None:
+        tau_lik = node.parents['tau']
+
+    r1 = node - mu_lik
+    r2 = pymc.LinearCombination('', (r1 * tau_lik,), (r1,))
+
+    alpha_post = prior.parents['alpha'] + NumpyAlen(node)/2.
+    beta_post = prior.parents['beta'] + r2/2.
+
+    parents_post = {'alpha': alpha_post, 'beta': beta_post}
+
+    posterior_name = "{}-post".format(prior.__name__)
+    posterior = pymc.Gamma(posterior_name, **parents_post)
+    posterior.isposterior = True
+    posterior.posterior_wrt = node
+    posterior.prior = prior
+    prior.posterior = posterior
+    return posterior
+
+
+def norm_norm_post(beta_rv, obs, mu_obs=None, tau_obs=None, **kwargs):
+    r""" Create a posterior stochastic for a normal variable that
+    acts as the mean parameter for another normal variable.
+
+     This is basically how we get the posterior mean:
+     C^{-1} m = R^{-1} a + F V^{-1} y
+
+    Parameters
+    ==========
+    beta_rv: pymc.Stochastic
+        The prior stochastic.
+    obs: pymc.Variable, or np.ndarray
+        The child/observation.
+    mu_obs: pymc.Variable, or np.ndarray
+        A linear transform applied to ``beta_rv``
+        representing :math:`y = X \beta`.
+    tau_obs: pymc.Variable, or np.ndarray
+        The precision for ``obs``.
+
+    Returns
+    =======
+    A pymc.Normal object representing the posterior of ``beta_rv``
+    given ``obs``.
+    """
+    if mu_obs is None:
+        mu_obs = obs.parents['mu']
+    if tau_obs is None:
+        tau_obs = obs.parents['tau']
+
+    if isinstance(mu_obs, pymc.LinearCombination):
+        assert beta_rv is mu_obs.y[0]
+        X, = mu_obs.x
+    else:
+        assert beta_rv is mu_obs
+        X = 1
+
+    #if isinstance(tau_obs, pymc.LinearCombination):
+    #    tau_obs_const, = tau_obs.x
+    #    tau_obs_gam, = tau_obs.y
+    #else:
+    #    tau_obs_const = 1
+    #    tau_obs_gam = tau_obs
+
+    tau_beta = beta_rv.parents['tau']
+    mu_beta = beta_rv.parents['mu']
+
+    # Apply the obs's mask so that we deal with only the relevant terms.
+    obs_mask = getattr(obs, 'mask', None)
+    if obs_mask is not None:
+        X = X[obs_mask]
+        obs = obs[obs_mask]
+
+    def rhs(t_b_=tau_beta, m_b_=mu_beta, X_=X,
+            t_y_=tau_obs, y_=obs, b_s_=np.shape(beta_rv)):
+        m_b_ = np.array(np.broadcast_to(m_b_, b_s_, subok=True))
+        t_b_ = np.array(np.broadcast_to(t_b_, b_s_, subok=True))
+        #res = np.dot(t_b_, m_b_) + np.dot(X_.T * t_y_, y_)
+        res = t_b_ * m_b_ + np.dot(X_.T * t_y_, np.ravel(y_))
+        return np.squeeze(res)
+
+    rhs = pymc.Lambda('{}-rhs'.format(beta_rv.__name__), rhs,
+                      trace=False)
+
+    def tau_update(t_b_=tau_beta, X_=X, t_y_=tau_obs):
+        X_ = np.array(X_)
+        t_b_ = np.array(np.broadcast_to(t_b_,
+                                        np.shape(X_)[-1], subok=True))
+        t_y_ = np.array(np.broadcast_to(t_y_,
+                                        np.alen(X_), subok=True))
+        #res = t_b_ + np.dot(X_.T * t_y_, X_)
+        X_t_y = np.einsum('ij,i->ij', X_, np.atleast_1d(t_y_))
+        res = t_b_ + np.sum(X_t_y * X_, axis=0)
+        return res
+
+    tau_post = pymc.Lambda('{}-tau-post'.format(beta_rv.__name__),
+                           tau_update, trace=False)
+
+    def mu_update(t_p_=tau_post, rhs_=rhs):
+        #res = np.linalg.solve(t_p_, rhs_)
+        res = rhs_/t_p_
+        return res
+
+    mu_post = pymc.Lambda('{}-mu-post'.format(beta_rv.__name__),
+                          mu_update, trace=False)
+
+    beta_post = pymc.Normal("{}-post".format(beta_rv.__name__),
+                            mu_post, tau_post, **kwargs)
+
+    beta_post.isposterior = True
+    beta_post.posterior_wrt = obs
+    beta_post.prior = beta_rv
+    beta_rv.posterior = beta_post
+
+    return beta_post

--- a/amimodels/normal_hmm.py
+++ b/amimodels/normal_hmm.py
@@ -14,7 +14,7 @@ import pymc
 from .stochastics import HMMStateSeq, TransProbMatrix
 from .hmm_utils import compute_trans_freqs, compute_steady_state
 from .deterministics import (HMMLinearCombination, KIndex, NumpyTake,
-                             NumpyChoose, NumpyHstack)
+                             NumpyChoose, MergeIndexed)
 
 
 def get_stochs_excluding(stoch, excluding):
@@ -758,8 +758,7 @@ def make_normal_hmm(y_data, X_data, initial_params=None, single_obs_var=False,
     lambdas = pymc.TupleContainer(lambda_list)
     beta_taus = pymc.TupleContainer(beta_tau_list)
 
-    mu = NumpyHstack(mu_k_list)
-    mu.keep_trace = True
+    mu = MergeIndexed(mu_k_list, state_obs_idx, trace=True)
     #mu = HMMLinearCombination('mu', X_data, betas, states)
 
     if np.alen(V_invs) == 1:

--- a/amimodels/normal_hmm.py
+++ b/amimodels/normal_hmm.py
@@ -759,12 +759,14 @@ def make_normal_hmm(y_data, X_data, initial_params=None, single_obs_var=False,
     beta_taus = pymc.TupleContainer(beta_tau_list)
 
     mu = NumpyHstack(mu_k_list)
+    mu.keep_trace = True
     #mu = HMMLinearCombination('mu', X_data, betas, states)
 
     if np.alen(V_invs) == 1:
         V_inv = V_invs[0]
     else:
-        V_inv = NumpyChoose(states, V_inv_list)
+        V_inv = NumpyChoose(states, V_inv_list,
+                            out=None)
 
     y_observed = False
     if y_data is not None:

--- a/amimodels/normal_hmm.py
+++ b/amimodels/normal_hmm.py
@@ -708,8 +708,8 @@ def make_normal_hmm(y_data, X_data, initial_params=None, single_obs_var=False,
         size_k = size_k if size_k > 1 else None
 
         # Local shrinkage terms:
-        lambda_k = pymc.HalfCauchy('lambdas-{}'.format(k),
-                                   0., 1., size=size_k)
+        lambda_k = pymc.Cauchy('lambdas-{}'.format(k),
+                               0., 1., size=size_k)
 
         # We're initializing the scale of the global
         # shrinkage parameter's distribution with a decent,
@@ -721,7 +721,7 @@ def make_normal_hmm(y_data, X_data, initial_params=None, single_obs_var=False,
                                       np.sqrt(1/V_i) / np.sqrt(np.log(s_)),
                                       trace=False)
             # Global shrinkage term:
-            eta_k = pymc.HalfCauchy('eta-{}'.format(k), 0., eta_k_scale)
+            eta_k = pymc.Cauchy('eta-{}'.format(k), 0., eta_k_scale)
             eta_list += (eta_k,)
 
             beta_tau_k = (lambda_k * eta_k)**(-2)

--- a/amimodels/step_methods.py
+++ b/amimodels/step_methods.py
@@ -191,9 +191,12 @@ class PosteriorSampler(pymc.StepMethod):
     """
     @classmethod
     def competence(cls, targets):
+        if not isinstance(targets, (list, tuple, set)):
+            targets = (targets,)
+
         if all([isinstance(getattr(t_, 'posterior', None), pymc.Node)
                 for t_ in targets]):
-            return 4
+            return 100
         else:
             return 0
 
@@ -202,7 +205,7 @@ class PosteriorSampler(pymc.StepMethod):
 
     def step(self):
         for s_ in self.stochastics:
-            s_.value = pymc.utils.value(s_.posterior)
+            s_.value = s_.posterior.random()
 
 
 class ExtStepMethod(pymc.StepMethod):

--- a/amimodels/stochastics.py
+++ b/amimodels/stochastics.py
@@ -33,7 +33,7 @@ def dvalue_class(cls, *args, **kwargs):
                    (cls, object), dcls)
 
     value_prop = property(lambda self:
-                          getattr(self._dvalue, 'value', self._dvalue),
+                          pymc.utils.value(self._dvalue),
                           lambda self, value:
                           setattr(self, '_dvalue', value),
                           lambda *x, **y: None)

--- a/tests/test_graph_ops.py
+++ b/tests/test_graph_ops.py
@@ -1,0 +1,274 @@
+from __future__ import division
+
+import sys
+
+import pandas as pd
+import numpy as np
+import pymc
+
+import pytest
+from numpy.testing import assert_array_equal
+
+from amimodels.graph import parse_node_partitions, normal_node_update
+from amimodels.normal_hmm import make_normal_hmm
+
+if hasattr(sys, '_called_from_test'):
+    slow = pytest.mark.skipif(
+        not pytest.config.getoption("--runslow"),
+        reason="need --runslow option to run"
+    )
+
+
+@pytest.fixture(params=[np.array([False]*10),
+                        np.array([True]*5 + [False]*5),
+                        np.array([False]*5 + [True] + [False]*4),
+                        ])
+def hmm_masked(request):
+
+    np.random.seed(2352523)
+    N_obs = np.alen(request.param)
+    y_obs = pd.Series(np.arange(N_obs))
+    X_matrices = [pd.DataFrame(np.ones((N_obs, 1))),
+                  pd.DataFrame(np.ones((N_obs, 2)))]
+
+    beta_1_tau_rv = pymc.Gamma('beta-1-tau', 1/2., 1/2., value=1e-2)
+    beta_2_tau_rv = pymc.Gamma('beta-2-tau', 1/2., 1/2., size=2,
+                               value=np.array([2e-2, 3e-2]))
+
+    beta_1_rv = pymc.Normal('beta-1', 1, beta_1_tau_rv, value=1)
+    beta_2_rv = pymc.Normal('beta-2', np.array([2, 2]),
+                            beta_2_tau_rv, size=2,
+                            value=np.array([2, 2]))
+    betas = [beta_1_rv, beta_2_rv]
+
+    from amimodels.deterministics import HMMLinearCombination
+    states_rv = pymc.Binomial('states', 1, 0.5, size=np.alen(y_obs))
+    mu_rv = HMMLinearCombination('mu', X_matrices,
+                                 [beta_1_rv, beta_2_rv], states_rv)
+
+    y_tau_rv = pymc.Gamma('y-tau', 1/2., 1/2., value=1.)
+
+    taus = [y_tau_rv, y_tau_rv]
+
+    y_obs_val = np.ma.masked_array(y_obs, request.param, dtype=np.float)
+
+    y_rv = pymc.Normal('y', mu_rv, y_tau_rv,
+                       value=y_obs_val, observed=True)
+
+    return y_rv, states_rv, betas, taus, X_matrices
+
+
+def test_collapse(hmm_masked):
+    """ Test that simple normal observation distribution marginalization
+    on a normally distributed mean parameter works with masked/missing
+    observations.  This test uses a basic HMM state sequence.
+    """
+
+    # DEBUG:
+    #from collections import namedtuple
+    #Request = namedtuple('Request', ['param'])
+    #request = Request(np.array([False]*10))
+    #request = Request(np.array([False]*5 + [True] + [False]*4))
+    #y_rv, states_rv, betas, X_matrices = hmm_masked(request)
+
+    y_rv, states_rv, betas, taus, X_matrices = hmm_masked
+
+    updates = parse_node_partitions(y_rv)
+
+    for k, node_k in enumerate(updates):
+        mu_k = node_k.parents['mu']
+        tau_k = node_k.parents['tau']
+        which_k = pymc.utils.value(states_rv) == k
+
+        assert_array_equal(pymc.utils.value(mu_k),
+                           pymc.utils.value(y_rv.parents['mu'])[which_k])
+
+        assert np.array_equiv(pymc.utils.value(tau_k),
+                              pymc.utils.value(taus[k]))
+
+        node_k_mask = pymc.utils.value(getattr(node_k, '_mask', None))
+        assert_array_equal(np.ma.masked_array(pymc.utils.value(node_k),
+                                              node_k_mask),
+                           pymc.utils.value(y_rv)[which_k])
+
+    normal_node_update(y_rv, updates)
+
+    y_marginal, = y_rv.marginals
+
+    assert y_marginal.observed == y_rv.observed
+    assert_array_equal(y_marginal.value, y_rv.value)
+    assert_array_equal(y_marginal.mask, y_rv.mask)
+
+    true_marg_mu = np.fromiter((np.dot(X_matrices[s_].iloc[t_],
+                                       betas[s_].parents['mu']).squeeze()
+                                for t_, s_ in enumerate(pymc.utils.value(states_rv))),
+                               dtype=np.float)
+    assert_array_equal(pymc.utils.value(y_marginal.parents['mu']),
+                       true_marg_mu)
+
+    # This is called 'lam' when the marginal is t-distributed.
+    true_marg_tau = np.fromiter((
+        np.reciprocal(1 / pymc.utils.value(y_rv.parents['tau']) +
+                      np.sum(np.square(X_matrices[s_].iloc[t_]) /
+                             pymc.utils.value(betas[s_].parents['tau'])))
+        for t_, s_ in enumerate(pymc.utils.value(states_rv))),
+        dtype=np.float)
+
+    assert_array_equal(pymc.utils.value(y_marginal.parents['lam']),
+                       true_marg_tau)
+
+    for k, marg_part in enumerate(y_marginal.partitions):
+        mu_k = marg_part.parents['mu']
+        lam_k = marg_part.parents['lam']
+        which_k = pymc.utils.value(states_rv) == k
+        assert_array_equal(pymc.utils.value(mu_k),
+                           true_marg_mu[which_k])
+        assert_array_equal(pymc.utils.value(lam_k),
+                           true_marg_tau[which_k])
+
+
+@pytest.mark.skip(reason="In progress...")
+def test_collapse_norm_hmm():
+    """ Test that simple normal observation distribution marginalization
+    on a normally distributed mean parameter works.
+    """
+
+    np.random.seed(2352523)
+    N_obs = 20
+    #y_obs = pd.Series(np.arange(N_obs))
+    y_obs = pd.Series(np.zeros(N_obs))
+    X_matrices = [pd.DataFrame(np.ones((N_obs, 1))),
+                  pd.DataFrame(np.ones((N_obs, 2)))]
+
+    norm_hmm = make_normal_hmm(y_obs, X_matrices)
+    node, = norm_hmm.observed_stochastics
+
+    #from amimodels.graph import *
+    #from amimodels.deterministics import *
+    updates = parse_node_partitions(node)
+
+    normal_node_update(node, updates)
+
+    y_marginal, = norm_hmm.y_rv.marginals
+
+    # Get rid of the dependencies on this node
+    # and create a new model with the marginal
+    # replacing the un-marginalized.
+    #obs_node.parents.detach_extended_parents()
+    y_marginal.parents['mu'].keep_trace = True
+    new_nodes = set((y_marginal, y_marginal.parents['mu'])) |\
+        y_marginal.extended_parents
+
+    #_ = [n_ for n_ in new_nodes]
+    new_norm_hmm = pymc.Model(new_nodes)
+
+    mcmc_step = pymc.MCMC(new_norm_hmm.variables)
+
+    mcmc_step.assign_step_methods()
+    mcmc_step.step_method_dict
+
+    mcmc_step.sample(200)
+
+    mcmc_step.db.trace_names
+
+    new_norm_hmm.get_node('states').stats()
+    new_norm_hmm.get_node('mu_y_marg').stats()
+    #y_marginal.parents['mu'].trace()
+
+
+@pytest.mark.skip(reason="In progress...")
+def test_collapse_binomial():
+    """ Test for a binomial sequence.
+    TODO: Finish
+    """
+
+    np.random.seed(2352523)
+    N_obs = 20
+    y_obs = pd.DataFrame(np.ones(N_obs))
+    X_matrices = [pd.DataFrame(np.ones((N_obs, 1))),
+                  pd.DataFrame(np.ones((N_obs, 2)))]
+
+    from amimodels.deterministics import HMMLinearCombination
+    from amimodels.stochastics import HMMStateSeq
+
+    beta_1_tau_rv = pymc.Gamma('beta-1-tau', 1/2., 1/2.)
+    beta_2_tau_rv = pymc.Gamma('beta-2-tau', 1/2., 1/2., size=2)
+    #beta_1_tau_rv = pymc.HalfCauchy('beta-1-tau', 0, 1)
+    #beta_2_tau_rv = pymc.HalfCauchy('beta-2-tau', 0, 1, size=2)
+    #beta_1_tau_rv = 1.
+    #beta_2_tau_rv = np.tile(2., (2,))
+    beta_1_rv = pymc.Normal('beta-1', 1, beta_1_tau_rv)
+    beta_2_rv = pymc.Normal('beta-2', 0, beta_2_tau_rv, size=2)
+
+    states_rv = pymc.Binomial('states', 1, 0.5, size=np.alen(y_obs))
+    mu_rv = HMMLinearCombination('mu', X_matrices,
+                                 [beta_1_rv, beta_2_rv], states_rv)
+    #mu_rv = pymc.LinearCombination('mu', [X_matrices[1]], [beta_2_rv])
+    #mu_rv = 0.
+
+    y_tau_rv = pymc.Gamma('y-tau', 1/2., 1/2.)
+    #y_tau_rv = pymc.HalfCauchy('y-tau', 0, 1)
+    #y_tau_rv = 1.
+
+    y_obs_val = np.asarray(y_obs).ravel()
+    #y_obs.iloc[5] = None
+    #y_obs.iloc[12] = None
+    #y_obs_val = np.ma.masked_invalid(y_obs)
+
+    y_rv = pymc.Normal('y', mu_rv, y_tau_rv,
+                       value=y_obs_val, observed=True)
+    #y_rv = pymc.Normal('y', mu_rv, y_tau_rv)
+
+    node = y_rv
+    updates = parse_node_partitions(node)
+    normal_node_update(node, updates)
+
+    y_marg, = y_rv.marginals
+
+    assert_array_equal(y_marg.value, y_rv.value)
+    assert_array_equal(y_marg.parents['mu'].value,
+                       np.array([1, 0])[states_rv.value])
+    #np.reciprocal(1/y_tau_rv.value + np.transpose(X_matrices[0] /
+    #              beta_1_rv.parents['tau'].value).dot(X_matrices[0]))
+    #assert_array_equal(y_marg.parents['tau'].value,
+    #                   np.array([1, 0])[states_rv.value])
+
+
+@pytest.mark.skip(reason="In progress...")
+def test_multiple_partitions():
+    """ Test that we can process multiple partitions of a node.
+    TODO, FIXME: We currently can't handle this.
+    """
+
+    np.random.seed(2352523)
+    N_obs = 20
+    y_obs = pd.Series(np.arange(N_obs))
+    X_matrices = [pd.DataFrame(np.ones((N_obs, 1))),
+                  pd.DataFrame(np.ones((N_obs, 2)))]
+
+    norm_hmm = make_normal_hmm(y_obs, X_matrices)
+
+    from amimodels.stochastics import HMMStateSeq
+    tau_states_rv = HMMStateSeq("tau_states",
+                                np.asarray([[0.9], [.1]]), N_obs)
+
+    from amimodels.deterministics import NumpyChoose
+    V_inv = NumpyChoose(tau_states_rv, norm_hmm.V_inv_list,
+                        out=None)
+
+    old_obs_node, = norm_hmm.observed_stochastics
+
+    node = pymc.Normal('y_rv', old_obs_node.parents['mu'],
+                       V_inv, value=old_obs_node.value,
+                       observed=True)
+
+    #from amimodels.graph import *
+    #from amimodels.deterministics import *
+
+    updates = parse_node_partitions(node)
+
+
+if __name__ == "__main__":
+    import pytest
+    pytest.main(["-x", "-s", "--pdbcls=IPython.core.debugger:Pdb",
+                "tests/test_graph_ops.py::test_collapse"])

--- a/tests/test_graph_ops.py
+++ b/tests/test_graph_ops.py
@@ -89,7 +89,7 @@ def test_collapse(hmm_masked):
                               pymc.utils.value(taus[k]))
 
         node_k_mask = pymc.utils.value(getattr(node_k, '_mask', None))
-        assert_array_equal(np.ma.masked_array(pymc.utils.value(node_k),
+        assert_array_equal(np.ma.masked_array(node_k.value,
                                               node_k_mask),
                            pymc.utils.value(y_rv)[which_k])
 

--- a/tests/test_normal_hmm.py
+++ b/tests/test_normal_hmm.py
@@ -456,4 +456,3 @@ def test_example_1():
     mcmc_step.assign_step_methods()
 
     # TODO: Check results.
-

--- a/tests/test_normal_hmm.py
+++ b/tests/test_normal_hmm.py
@@ -340,6 +340,7 @@ def test_sinusoid():
                rtol=np.array([0.25, 0.1, 0.1]))
 
 
+
 @pytest.mark.skip(reason="In progress...")
 def test_prediction(
                     mcmc_iters=200
@@ -423,4 +424,36 @@ def test_prediction(
     # TODO: Not easy to compare these unless we have very strong
     # predictors.  Even then, the states will vary freely.
     #sqrd_err = np.abs(mu_pred_df.values - y_oos_df.values).mean()
+
+
+@pytest.mark.skip(reason="In progress...")
+def test_example_1():
+    """ TODO
+    """
+    import pickle
+    import patsy
+
+    model_data, formulas = pickle.load(open('tests/data/test_example_1.pkl', 'rb'))
+
+    X_matrices = []
+    for formula in formulas:
+        y, X = patsy.dmatrices(formula, model_data,
+                               return_type='dataframe')
+        X_matrices += [X]
+
+    init_params = None  # gmm_norm_hmm_init_params(y, X_matrices)
+
+    norm_hmm = make_normal_hmm(y, X_matrices, init_params,
+                                include_ppy=True)
+
+    # Some very basic, generic initializations for the state parameters.
+    norm_hmm.betas[0].value = 0
+    b1_0 = norm_hmm.betas[1].value.copy()
+    b1_0[0] = float(y.mean())
+    norm_hmm.betas[1].value = b1_0
+
+    mcmc_step = pymc.MCMC(norm_hmm.variables)
+    mcmc_step.assign_step_methods()
+
+    # TODO: Check results.
 

--- a/tests/test_step_methods.py
+++ b/tests/test_step_methods.py
@@ -352,3 +352,4 @@ def test_normal_normal_step():
 
     assert_hpd(mcmc_step.betas[0], betas_true[0], alpha=0.05)
     assert_hpd(mcmc_step.betas[1], betas_true[1], alpha=0.05)
+


### PR DESCRIPTION
This PR directly addresses #12 and #8 and similar future (marginalization, conjugate dists) requests.  Major changes include:
- (Semi-)automatic creation of normal and gamma conjugate distribution variables (i.e. marginal and posterior distributions).
  - This should really help with any extensions to the models within-states (e.g. dynamic linear models, Kalman filters, sparsity priors on regression parameters, etc.).
  - Consider this feature as more of a proof-of-concept (see notes below).
- More structured deterministics (including additional Numpy operations), simple indexing deterministics that track the terms they partition--in special cases.
- Simple symbolic algebra processing (products only). 

These changes really highlight the eventual need to move to PyMC3/Theano.  Ultimately the graph processing that's being naively done in this PR is best suited for Theano, and the symbolic algebra should be handled by SymPy (or possibly [LogPy](https://github.com/logpy/logpy)).
